### PR TITLE
Encoding debug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,4 @@ RUN mkdir -p  /usr/bin/snowflake_odbc/log
 ENV SIMBAINI /etc/simba.snowflake.ini
 ENV SSL_DIR /usr/bin/snowflake_odbc/SSLCertificates/nssdb
 ENV LD_LIBRARY_PATH /usr/bin/snowflake_odbc/lib
+ENV LANG en_US.UTF-8

--- a/odbc_test.php
+++ b/odbc_test.php
@@ -1,0 +1,36 @@
+<?php
+
+$dsn = "Driver=SnowflakeDSIIDriver;Server=" .  getenv('SNOWFLAKE_HOST');
+$dsn .= ";Port=443";
+$dsn .= ";Tracing=6";
+$dsn .= ";Database=\"". getenv('SNOWFLAKE_DATABASE') . "\"";
+$dsn .= ";Warehouse=\"". getenv('SNOWFLAKE_WAREHOUSE') . "\"";
+
+
+$connection = odbc_connect($dsn, getenv('SNOWFLAKE_USER'), getenv('SNOWFLAKE_PASSWORD'));
+
+function fetchAll($connection, $sql, $bind = [])
+{
+    $stmt = odbc_prepare($connection, $sql);
+    odbc_execute($stmt, $bind);
+    $rows = [];
+    while ($row = odbc_fetch_array($stmt)) {
+        $rows[] = $row;
+    }
+    odbc_free_result($stmt);
+    return $rows;
+}
+
+function query($connection, $sql, $bind = [])
+{
+    $stmt = odbc_prepare($connection, $sql);
+    odbc_execute($stmt, $bind);
+    odbc_free_result($stmt);
+}
+
+query($connection, "DROP SCHEMA IF EXISTS test");
+query($connection, "CREATE SCHEMA test");
+query($connection, "USE SCHEMA test");
+query($connection, 'CREATE TABLE test (col1 varchar, col2 varchar)');
+query($connection, 'INSERT INTO  test VALUES (\'šperky.cz\', \'módní doplňky.cz\')');
+var_dump(fetchAll($connection, "select * from test"));

--- a/odbc_test.php
+++ b/odbc_test.php
@@ -6,7 +6,6 @@ $dsn .= ";Tracing=6";
 $dsn .= ";Database=\"". getenv('SNOWFLAKE_DATABASE') . "\"";
 $dsn .= ";Warehouse=\"". getenv('SNOWFLAKE_WAREHOUSE') . "\"";
 
-
 $connection = odbc_connect($dsn, getenv('SNOWFLAKE_USER'), getenv('SNOWFLAKE_PASSWORD'));
 
 function fetchAll($connection, $sql, $bind = [])
@@ -32,5 +31,5 @@ query($connection, "DROP SCHEMA IF EXISTS test");
 query($connection, "CREATE SCHEMA test");
 query($connection, "USE SCHEMA test");
 query($connection, 'CREATE TABLE test (col1 varchar, col2 varchar)');
-query($connection, 'INSERT INTO  test VALUES (\'šperky.cz\', \'módní doplňky.cz\')');
+query($connection, 'INSERT INTO  test VALUES (\'šperky.cz\', \'módní doplňěščřžýáíéky.cz\')');
 var_dump(fetchAll($connection, "select * from test"));

--- a/src/Snowflake/Connection.php
+++ b/src/Snowflake/Connection.php
@@ -64,6 +64,8 @@ class Connection
         }
         
         try {
+
+            echo $dsn . "\n";
             $connection = odbc_connect($dsn, $options['user'], $options['password']);
 
             if (isset($options['database'])) {

--- a/tests/SnowflakeTest.php
+++ b/tests/SnowflakeTest.php
@@ -62,6 +62,22 @@ class SnowflakeTest extends \PHPUnit_Framework_TestCase
         $connection->query('DROP TABLE "' . $this->destSchemaName . '"."TEST" RESTRICT');
     }
 
+    public function testConnectionEncoding()
+    {
+        $connection = new Connection([
+            'host' => getenv('SNOWFLAKE_HOST'),
+            'port' => getenv('SNOWFLAKE_PORT'),
+            'database' => getenv('SNOWFLAKE_DATABASE'),
+            'warehouse' => getenv('SNOWFLAKE_WAREHOUSE'),
+            'user' => getenv('SNOWFLAKE_WAREHOUSE'),
+            'password' => getenv('SNOWFLAKE_PASSWORD'),
+            'tracing' => 6,
+        ]);
+
+        $connection->query('CREATE TABLE "' . $this->destSchemaName . '"."TEST" (col1 varchar, col2 varchar)');
+        $connection->query('INSERT INTO  "' . $this->destSchemaName . '"."TEST" VALUES (\'šperky.cz\', \'módní doplňky.cz\')');
+    }
+
     /**
      * This should not exhaust memory
      */

--- a/tests/SnowflakeTest.php
+++ b/tests/SnowflakeTest.php
@@ -26,7 +26,7 @@ class SnowflakeTest extends \PHPUnit_Framework_TestCase
             'port' => getenv('SNOWFLAKE_PORT'),
             'database' => getenv('SNOWFLAKE_DATABASE'),
             'warehouse' => getenv('SNOWFLAKE_WAREHOUSE'),
-            'user' => getenv('SNOWFLAKE_WAREHOUSE'),
+            'user' => getenv('SNOWFLAKE_USER'),
             'password' => getenv('SNOWFLAKE_PASSWORD'),
         ]);
         $this->initData();

--- a/tests/SnowflakeTest.php
+++ b/tests/SnowflakeTest.php
@@ -76,6 +76,16 @@ class SnowflakeTest extends \PHPUnit_Framework_TestCase
 
         $connection->query('CREATE TABLE "' . $this->destSchemaName . '"."TEST" (col1 varchar, col2 varchar)');
         $connection->query('INSERT INTO  "' . $this->destSchemaName . '"."TEST" VALUES (\'šperky.cz\', \'módní doplňky.cz\')');
+
+        $data = $connection->fetchAll('SELECT * FROM "' . $this->destSchemaName . '"."TEST"');
+        var_dump($data);
+
+        $this->assertEquals([
+            [
+                'COL1' => 'šperky.cz',
+                'COL2' => 'módní doplňky.cz',
+            ],
+        ], $data);
     }
 
     /**


### PR DESCRIPTION
ODBC driver doesn't handle well UTF-8 characters:
```
INSERT INTO  "TEST" VALUES ('šperky.cz', 'módní doplňky.cz');
```
Results in:
![image](https://cloud.githubusercontent.com/assets/903531/16333141/f9e4fa1a-39f9-11e6-83d3-9bc406ea8764.png)

This behaviour is simulated in this PR. It can be executed running:

 - Clone this repo
- run `docker-compose build`
- export snowflake connection env variables, see below
- run:
```
docker-compose run \                                   
  -e SNOWFLAKE_HOST=$SNOWFLAKE_HOST \
  -e SNOWFLAKE_PORT=$SNOWFLAKE_PORT \
  -e SNOWFLAKE_USER=$SNOWFLAKE_USER \
  -e SNOWFLAKE_PASSWORD=$SNOWFLAKE_PASSWORD \
  -e SNOWFLAKE_DATABASE=$SNOWFLAKE_DATABASE \
  -e SNOWFLAKE_WAREHOUSE=$SNOWFLAKE_WAREHOUSE \
  tests php odbc_test.php
```