### PR TITLE
Snowflake slices limit

### DIFF
--- a/src/Snowflake/Connection.php
+++ b/src/Snowflake/Connection.php
@@ -81,10 +81,10 @@ class Connection
                 if (stristr($e->getMessage(), "S1000") !== false) {
                     $attemptNumber++;
                     if ($attemptNumber > $maxBackoffAttempts) {
-                        throw new Exception("Initializing Snowflake connection failed: " . $e->getMessage(), null, $e);
+                        throw new Exception("Initializing Snowflake connection failed: " . $e->getMessage(), 0, $e);
                     }
                 } else {
-                    throw new Exception("Initializing Snowflake connection failed: " . $e->getMessage(), null, $e);
+                    throw new Exception("Initializing Snowflake connection failed: " . $e->getMessage(), 0, $e);
                 }
             }
         } while ($this->connection === null);

--- a/src/Snowflake/CsvImport.php
+++ b/src/Snowflake/CsvImport.php
@@ -9,12 +9,10 @@ class CsvImport extends CsvImportBase
     protected function importDataToStagingTable(string $stagingTableName, array $columns, array $sourceData): void
     {
         foreach ($sourceData as $csvFile) {
-            $this->importTable(
+            $this->importTableFromCsv(
                 $stagingTableName,
                 $csvFile,
-                [
-                    'isManifest' => false,
-                ]
+                false
             );
         }
     }

--- a/src/Snowflake/CsvImportBase.php
+++ b/src/Snowflake/CsvImportBase.php
@@ -63,24 +63,24 @@ abstract class CsvImportBase extends ImportBase
         }
     }
 
-    private function importTableFromSingleFile(string $stableName, CsvFile $csvFile)
+    private function importTableFromSingleFile(string $stableName, CsvFile $csvFile): void
     {
         $this->executeCopyCommand(
             $this->generateSingleFileCopyCommand($stableName, $csvFile)
         );
     }
 
-    private function importTableFromSlicedFile(string $tableName, CsvFile $csvFile)
+    private function importTableFromSlicedFile(string $tableName, CsvFile $csvFile): void
     {
         $slicesPaths = $this->getFilesToDownloadFromManifest($csvFile->getPathname());
         foreach (array_chunk($slicesPaths, self::SLICED_FILES_CHUNK_SIZE) as $slicesChunk) {
             $this->executeCopyCommand(
-              $this->generateSlicedFileCopyCommand($tableName, $csvFile, $slicesChunk)
+                $this->generateSlicedFileCopyCommand($tableName, $csvFile, $slicesChunk)
             );
         }
     }
 
-    private function executeCopyCommand($sql)
+    private function executeCopyCommand(string $sql): void
     {
         $results = $this->connection->fetchAll($sql);
         foreach ($results as $result) {
@@ -110,7 +110,7 @@ abstract class CsvImportBase extends ImportBase
         );
     }
 
-    private function generateSlicedFileCopyCommand(string $tableName, CsvFile $csvFile, array $slicesPaths)
+    private function generateSlicedFileCopyCommand(string $tableName, CsvFile $csvFile, array $slicesPaths): string
     {
         $parsedS3Path = parse_url($csvFile->getPathname());
         $s3Prefix = 's3://' . $parsedS3Path['host'];
@@ -145,7 +145,7 @@ abstract class CsvImportBase extends ImportBase
         );
     }
 
-    private function createCopyCommandCsvOptions(CsvFile $csvFile, int $ignoreLinesCount)
+    private function createCopyCommandCsvOptions(CsvFile $csvFile, int $ignoreLinesCount): array
     {
         $csvOptions = [];
         $csvOptions[] = sprintf('FIELD_DELIMITER = %s', $this->quote($csvFile->getDelimiter()));

--- a/src/Snowflake/CsvImportBase.php
+++ b/src/Snowflake/CsvImportBase.php
@@ -73,7 +73,7 @@ abstract class CsvImportBase extends ImportBase
             $this->generateSingleFileCopyCommand(
                 $stableName,
                 $csvFile->getPathname(),
-               $csvOptions
+                $csvOptions
             )
         );
     }
@@ -124,7 +124,7 @@ abstract class CsvImportBase extends ImportBase
             $this->quote($this->s3region),
             implode(
                 ' ',
-               $csvOptions
+                $csvOptions
             )
         );
     }

--- a/src/Snowflake/CsvImportBase.php
+++ b/src/Snowflake/CsvImportBase.php
@@ -35,14 +35,7 @@ abstract class CsvImportBase extends ImportBase
         $this->s3region = $s3region;
     }
 
-    /**
-     * @param string $tableName
-     * @param CsvFile $csvFile
-     * @param array $options
-     *  - isManifest
-     * @throws Exception
-     */
-    protected function importTable(string $tableName, CsvFile $csvFile, array $options): void
+    protected function importTableFromCsv(string $tableName, CsvFile $csvFile, bool $isSliced): void
     {
         if ($csvFile->getEnclosure() && $csvFile->getEscapedBy()) {
             throw new Exception(
@@ -55,7 +48,7 @@ abstract class CsvImportBase extends ImportBase
         try {
             $timerName = 'copyToStaging-' . $csvFile->getBasename();
             Debugger::timer($timerName);
-            if (!empty($options['isManifest'])) {
+            if ($isSliced) {
                 $this->importTableFromSlicedFile($tableName, $csvFile);
             } else {
                 $this->importTableFromSingleFile($tableName, $csvFile);

--- a/src/Snowflake/CsvManifestImport.php
+++ b/src/Snowflake/CsvManifestImport.php
@@ -9,12 +9,10 @@ class CsvManifestImport extends CsvImportBase
     protected function importDataToStagingTable(string $stagingTableName, array $columns, array $sourceData): void
     {
         foreach ($sourceData as $csvFile) {
-            $this->importTable(
+            $this->importTableFromCsv(
                 $stagingTableName,
                 $csvFile,
-                [
-                    'isManifest' => true,
-                ]
+                true
             );
         }
     }

--- a/tests/Snowflake/ConnectionTest.php
+++ b/tests/Snowflake/ConnectionTest.php
@@ -16,7 +16,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $connection = new Connection([
             'host' => getenv('SNOWFLAKE_HOST'),
             'port' => getenv('SNOWFLAKE_PORT'),
-            'user' => getenv('SNOWFLAKE_WAREHOUSE'),
+            'user' => getenv('SNOWFLAKE_USER'),
             'password' => getenv('SNOWFLAKE_PASSWORD'),
         ]);
 
@@ -83,7 +83,7 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
             'port' => getenv('SNOWFLAKE_PORT'),
             'database' => getenv('SNOWFLAKE_DATABASE'),
             'warehouse' => getenv('SNOWFLAKE_WAREHOUSE'),
-            'user' => getenv('SNOWFLAKE_WAREHOUSE'),
+            'user' => getenv('SNOWFLAKE_USER'),
             'password' => getenv('SNOWFLAKE_PASSWORD'),
         ]);
     }

--- a/tests/Snowflake/ImportTest.php
+++ b/tests/Snowflake/ImportTest.php
@@ -244,11 +244,18 @@ class ImportTest extends \PHPUnit_Framework_TestCase
         $lemmaHeader = array_shift($expectedLemma);
         $expectedLemma = array_values($expectedLemma);
 
+        // large sliced manifest
+        $expectedLargeSlicedManifest = [];
+        $expectedLargeSlicedManifest[] = $escapingHeader;
+        for ($i = 0; $i < 1500; $i++) {
+            $expectedLargeSlicedManifest[] = ['a', 'b'];
+        }
+
         $s3bucket = getenv(self::AWS_S3_BUCKET_ENV);
 
         return [
             // full imports
-            [[new CsvFile("s3://{$s3bucket}/manifests/2cols-large/sliced.csvmanifest")], $escapingHeader, [], 'out.csv_2Cols', 'manifest' ],
+            [[new CsvFile("s3://{$s3bucket}/manifests/2cols-large/sliced.csvmanifest")], $escapingHeader, $expectedLargeSlicedManifest, 'out.csv_2Cols', 'manifest' ],
             [[new CsvFile("s3://{$s3bucket}/empty.manifest")], $escapingHeader, [], 'out.csv_2Cols', 'manifest' ],
             [[new CsvFile("s3://{$s3bucket}/lemma.csv")], $lemmaHeader, $expectedLemma, 'out.lemma'],
             [[new CsvFile("s3://{$s3bucket}/standard-with-enclosures.csv")], $escapingHeader, $expectedEscaping, 'out.csv_2Cols'],

--- a/tests/Snowflake/ImportTest.php
+++ b/tests/Snowflake/ImportTest.php
@@ -246,8 +246,7 @@ class ImportTest extends \PHPUnit_Framework_TestCase
 
         // large sliced manifest
         $expectedLargeSlicedManifest = [];
-        $expectedLargeSlicedManifest[] = $escapingHeader;
-        for ($i = 0; $i < 1500; $i++) {
+        for ($i = 0; $i <= 1500; $i++) {
             $expectedLargeSlicedManifest[] = ['a', 'b'];
         }
 

--- a/tests/Snowflake/ImportTest.php
+++ b/tests/Snowflake/ImportTest.php
@@ -248,6 +248,7 @@ class ImportTest extends \PHPUnit_Framework_TestCase
 
         return [
             // full imports
+            [[new CsvFile("s3://{$s3bucket}/manifests/2cols-large/sliced.csvmanifest")], $escapingHeader, [], 'out.csv_2Cols', 'manifest' ],
             [[new CsvFile("s3://{$s3bucket}/empty.manifest")], $escapingHeader, [], 'out.csv_2Cols', 'manifest' ],
             [[new CsvFile("s3://{$s3bucket}/lemma.csv")], $lemmaHeader, $expectedLemma, 'out.lemma'],
             [[new CsvFile("s3://{$s3bucket}/standard-with-enclosures.csv")], $escapingHeader, $expectedEscaping, 'out.csv_2Cols'],

--- a/tests/Snowflake/ImportTest.php
+++ b/tests/Snowflake/ImportTest.php
@@ -294,8 +294,8 @@ class ImportTest extends \PHPUnit_Framework_TestCase
                 [new CsvFile("s3://{$s3bucket}/with-ts.csv")],
                 ['col1', 'col2', '_timestamp'],
                 [
-                    ['a', 'b', 'Mon, 10 Nov 2014 13:12:06 Z'],
-                    ['c', 'd', 'Mon, 10 Nov 2014 14:12:06 Z'],
+                    ['a', 'b', '2014-11-10 13:12:06.000'],
+                    ['c', 'd', '2014-11-10 14:12:06.000'],
                 ],
                 'out.csv_2Cols',
             ],

--- a/tests/_data/csv-import/manifests/2cols-large/.gitignore
+++ b/tests/_data/csv-import/manifests/2cols-large/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/loadS3.php
+++ b/tests/loadS3.php
@@ -46,6 +46,26 @@ if ($objects) {
     ]);
 }
 
+// generate files
+$largeManifest = [
+    'entries' => []
+];
+for ($i = 0; $i <= 1500; $i++) {
+    $sliceName = sprintf('sliced.csv_%d', $i);
+    file_put_contents(
+        $source . '/manifests/2cols-large/' . $sliceName,
+        "\"a\",\"b\"\n"
+    );
+    $largeManifest['entries'][] = [
+        'url' => sprintf("s3://%s/manifests/2cols-large/%s", $bucket, $sliceName),
+        'mandatory' => true,
+    ];
+}
+file_put_contents(
+    $source . '/manifests/2cols-large/sliced.csvmanifest',
+    json_encode($largeManifest)
+);
+
 // Create a transfer object.
 $manager = new \Aws\S3\Transfer($client, $source, $dest, [
     'debug' => true,
@@ -107,6 +127,8 @@ $manifest = [
         ],
     ],
 ];
+
+// 4. More than 1000 slices
 
 $client->putObject([
     'Bucket' => $bucket,

--- a/tests/loadS3.php
+++ b/tests/loadS3.php
@@ -48,7 +48,7 @@ if ($objects) {
 
 // generate files
 $largeManifest = [
-    'entries' => []
+    'entries' => [],
 ];
 for ($i = 0; $i <= 1500; $i++) {
     $sliceName = sprintf('sliced.csv_%d', $i);


### PR DESCRIPTION
FIXES #39 

Podpora lodování sliced souborů s více než 1000 slices. Je to řešené tak že se to rozseká po tisícovkách a postupně se pomocí `COPY` s parameterm `FILES` naloaduje do SNFLK.

Řeším tam podivnost s tím že to generuje místo jedné query dvě (vypadá to že se to týká všech queries které mají delší SQL?) Vyřeším bokem přes support https://github.com/keboola/php-db-import/issues/39#issuecomment-384941695
