### PR TITLE
chore: upgrade Snowflake ODBC driver 2.25.12 → 3.18.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '7.4'
-          - '8.0'
           - '8.1'
           - '8.2'
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PHP_VERSION=8.1
 
-FROM php:${PHP_VERSION:-8.1}-cli-buster
+FROM php:${PHP_VERSION:-8.1}-cli-bullseye
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV COMPOSER_ALLOW_SUPERUSER 1
@@ -8,8 +8,11 @@ ENV COMPOSER_PROCESS_TIMEOUT 3600
 # snowflake - charset settings
 ENV LANG en_US.UTF-8
 
-ARG SNOWFLAKE_ODBC_VERSION=2.25.12
-ARG SNOWFLAKE_GPG_KEY=630D9F3CAB551AF3
+ARG SNOWFLAKE_ODBC_VERSION=3.18.0
+ARG SNOWFLAKE_GPG_KEY=6C983AB7AFE2E5951C6C47B13C98F63C9292CE02
+# debsig-verify 0.23 (Debian bullseye) resolves the policy/keyring by the 64-bit
+# key id (last 16 hex of the fingerprint), not the full fingerprint.
+ARG SNOWFLAKE_GPG_KEY_ID=3C98F63C9292CE02
 
 RUN apt-get update \
   && apt-get install -y unzip \
@@ -43,15 +46,15 @@ RUN set -ex; \
     docker-php-source delete
 
 ## install snowflake drivers
-COPY ./docker/snowflake/generic.pol /etc/debsig/policies/$SNOWFLAKE_GPG_KEY/generic.pol
+COPY ./docker/snowflake/generic.pol /etc/debsig/policies/$SNOWFLAKE_GPG_KEY_ID/generic.pol
 COPY ./docker/snowflake/simba.snowflake.ini /usr/lib/snowflake/odbc/lib/simba.snowflake.ini
 
 RUN mkdir -p ~/.gnupg \
     && chmod 700 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
-    && mkdir -p /usr/share/debsig/keyrings/$SNOWFLAKE_GPG_KEY \
-    && gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys $SNOWFLAKE_GPG_KEY \
-    && gpg --export $SNOWFLAKE_GPG_KEY > /usr/share/debsig/keyrings/$SNOWFLAKE_GPG_KEY/debsig.gpg \
+    && mkdir -p /usr/share/debsig/keyrings/$SNOWFLAKE_GPG_KEY_ID \
+    && gpg --keyserver hkp://keyserver.ubuntu.com --keyserver-options timeout=30 --recv-keys $SNOWFLAKE_GPG_KEY \
+    && gpg --export $SNOWFLAKE_GPG_KEY > /usr/share/debsig/keyrings/$SNOWFLAKE_GPG_KEY_ID/debsig.gpg \
     && curl https://sfc-repo.snowflakecomputing.com/odbc/linux/$SNOWFLAKE_ODBC_VERSION/snowflake-odbc-$SNOWFLAKE_ODBC_VERSION.x86_64.deb --output /tmp/snowflake-odbc.deb \
     && debsig-verify /tmp/snowflake-odbc.deb \
     && gpg --batch --delete-key --yes $SNOWFLAKE_GPG_KEY \

--- a/docker/snowflake/generic.pol
+++ b/docker/snowflake/generic.pol
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <!DOCTYPE Policy SYSTEM "http://www.debian.org/debsig/1.0/policy.dtd">
 <Policy xmlns="https://www.debian.org/debsig/1.0/">
-    <Origin Name="Snowflake Computing" id="630D9F3CAB551AF3" Description="Snowflake ODBC Driver DEB package"/>
+    <Origin Name="Snowflake Computing" id="3C98F63C9292CE02" Description="Snowflake ODBC Driver DEB package"/>
     <Selection>
-        <Required Type="origin" File="debsig.gpg" id="630D9F3CAB551AF3"/>
+        <Required Type="origin" File="debsig.gpg" id="3C98F63C9292CE02"/>
     </Selection>
     <Verification MinOptional="0">
-        <Required Type="origin" File="debsig.gpg" id="630D9F3CAB551AF3"/>
+        <Required Type="origin" File="debsig.gpg" id="3C98F63C9292CE02"/>
     </Verification>
 </Policy>


### PR DESCRIPTION
## Summary

Upgrades the Snowflake ODBC driver used by this library's test image from **2.25.12 → 3.18.0**, and refreshes the EOL Debian **buster** base to **bullseye** in the same PR (they are coupled — see below).

Linear: **DMD-1659** (platform-wide Snowflake ODBC driver audit/upgrade to 3.18.0).

## Why the base image must change in this PR

The old base `php:*-cli-buster` is EOL: Debian buster's apt repositories are archived, so `apt-get update` (step 2 of the Dockerfile) fails on a clean build. The ODBC upgrade cannot be validated without first getting onto a supported base.

**Base choice — bullseye, not bookworm:** the official `php:7.4-cli-bookworm` / `php:8.0-cli-bookworm` tags do not exist (bookworm variants start at 8.1). `bullseye` is still a supported (LTS) release and de-EOLs the base. See the matrix note below for the retained versions.

## Changes

- `Dockerfile`
  - `FROM php:${PHP_VERSION:-8.1}-cli-buster` → `-cli-bullseye`
  - `ARG SNOWFLAKE_ODBC_VERSION` `2.25.12` → `3.18.0`
  - `ARG SNOWFLAKE_GPG_KEY` `630D9F3CAB551AF3` → full fingerprint `6C983AB7AFE2E5951C6C47B13C98F63C9292CE02` (new Snowflake signing key generation)
  - New `ARG SNOWFLAKE_GPG_KEY_ID=3C98F63C9292CE02` for the debsig policy/keyring paths — `debsig-verify 0.23` on bullseye resolves the policy by the **64-bit key id** (last 16 hex of the fingerprint), not the full fingerprint. gpg operations still use the full fingerprint.
  - `gpg --recv-keys` gains `--keyserver-options timeout=30`
- `docker/snowflake/generic.pol` — `id` fields updated to `3C98F63C9292CE02`
- `.github/workflows/tests.yml` — dropped EOL PHP **7.4** and **8.0** from the build matrix (now `8.1`, `8.2`); see below

## CI matrix: dropped EOL 7.4 / 8.0 (maintainer decision)

PHP 7.4 and 8.0 are EOL. On this branch they fail not because of the ODBC install (which succeeds on every row) but because `aws-sdk-php` now requires PHP ≥ 8.1 (dependency drift). Per maintainer decision the two EOL rows are removed from the build matrix; ODBC 3.18.0 + bullseye is verified on 8.1 and 8.2 (both green). The `test_e2e` job (hardcoded PHP 8.1) is unchanged.

## Verification (local `docker build`)

Default PHP (8.1) and PHP 7.4 both built cleanly on bullseye during development (the ODBC install itself is version-agnostic):

```
debsig: Verified package from 'Snowflake ODBC Driver DEB package' (Snowflake Computing)
Setting up snowflake-odbc (3.18.0) ...
```

Runtime check on the 8.1 image:

```
$ odbcinst -q -d
[SnowflakeDSIIDriver]
$ php -m | grep -i odbc
odbc
$ ls -l /usr/lib/snowflake/odbc/lib/libSnowflake.so
-rwxr-xr-x 1 root root 246224688 ... /usr/lib/snowflake/odbc/lib/libSnowflake.so
```

`dpkg -i` reported **no** unmet `odbcinst` dependency — bullseye's `unixodbc` provides it, so no apt change was needed (the separate `odbcinst` package is only required on trixie).

## Out of scope

CI still authenticates to Snowflake with a **password** (`SNOWFLAKE_PASSWORD` secret, legacy user `GH_ACTIONS_LEGACY_CSV_IMPORT`). Snowflake is deprecating password auth in favour of key-pair (DMD-1688 family). A green ODBC build here could still fail the live `tests-snowflake` E2E on auth — that migration is tracked separately and intentionally not touched in this PR.

## Note

`keboola/php-db-import` is the legacy CSV importer, largely superseded by `keboola/php-db-import-export`, but it is not archived and its CI still runs live Snowflake tests — hence it is in scope for the ODBC audit.
